### PR TITLE
Last port/channel is prefixed

### DIFF
--- a/gon-cli/cmd/query_nfts.go
+++ b/gon-cli/cmd/query_nfts.go
@@ -70,8 +70,8 @@ func getUsersNfts(ctx context.Context, clientCtx client.Context, chain chains.Ch
 			panic("only IBC path class IDs are supported for CosmWasm chains right now")
 		}
 
-		lastPort := splitClassID[len(splitClassID)-3]
-		lastChannel := splitClassID[len(splitClassID)-2]
+		lastPort := splitClassID[0]
+		lastChannel := splitClassID[1]
 		bridgerContract := strings.TrimPrefix(lastPort, "wasm.")
 
 		nftContractQueryData, err := chains.Decoder.DecodeString(fmt.Sprintf(`{"nft_contract": {"class_id" : "%s"}}`, classID))


### PR DESCRIPTION
Example:
wasm.juno1stv6sk0mvku34fj2mqrlyru6683866n306mfv52tlugtl322zmks26kg7a/channel-93/wasm.stars1ve46fjrhcrum94c7d8yc2wsdz8cpuw73503e8qn9r44spr6dw0lsvmvtqh/channel-207/tribblez


Should use the juno wasm contract in the beginning to query the juno chain where the NFT last arrived.

You can simulate the issue by sending an NFT from Iris -> Stargaze -> Juno and trying to select the Juno NFT for transfer to any other chain.