### PR TITLE
Print flow path and direct self relay

### DIFF
--- a/gon-cli/cmd/root.go
+++ b/gon-cli/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	omniflixnfttypes "github.com/OmniFlix/onft/types"
 	nfttransfertypes "github.com/bianjieai/nft-transfer/types"
@@ -21,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/strangelove-ventures/lens/client/codecs/ethermint"
 	tmcfg "github.com/tendermint/tendermint/config"
-	"os"
 )
 
 const (
@@ -42,6 +43,9 @@ const (
 
 	selfRelayOption  OptionString = "Self Relay IBC message"
 	selfRelayCommand              = "self-relay"
+
+	selfRelayDirectOption  OptionString = "Self Relay IBC message Direct"
+	selfRelayCommandDirect              = "self-relay-direct"
 
 	toolsOption  OptionString = "Helper tools"
 	toolsCommand              = "tools"
@@ -108,6 +112,7 @@ func NewRootCmd(appHomeDir string) *cobra.Command {
 				transferNFTOption,
 				queryNFTSOption,
 				selfRelayOption,
+				selfRelayDirectOption,
 				toolsOption,
 				gonToolsOption,
 			}
@@ -125,6 +130,8 @@ func NewRootCmd(appHomeDir string) *cobra.Command {
 					topLevelChoice = queryNFTSOption
 				case selfRelayCommand:
 					topLevelChoice = selfRelayOption
+				case selfRelayCommandDirect:
+					topLevelChoice = selfRelayDirectOption
 				case toolsCommand:
 					topLevelChoice = toolsOption
 				case gonToolsCommand:
@@ -147,6 +154,9 @@ func NewRootCmd(appHomeDir string) *cobra.Command {
 				return queryNFTsInteractive(cmd)
 			case selfRelayOption:
 				selfRelayInteractive(cmd)
+				return nil
+			case selfRelayDirectOption:
+				selfRelay(cmd, args)
 				return nil
 			case toolsOption:
 				toolsInteractive(cmd, args)

--- a/gon-cli/cmd/root_self_relay.go
+++ b/gon-cli/cmd/root_self_relay.go
@@ -2,12 +2,18 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/gjermundgaraba/gon/chains"
 	"github.com/gjermundgaraba/gon/gorelayer"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"strconv"
 )
+
+type Filter struct {
+	chains.ChainData
+}
 
 func selfRelayInteractive(cmd *cobra.Command) {
 	ctx := cmd.Context()
@@ -25,6 +31,64 @@ func selfRelayInteractive(cmd *cobra.Command) {
 	destinationChain := chooseChain("Destination chain of transactions that needs relaying", sourceChain)
 
 	txHash := askForString("Transaction hash to relay", survey.WithValidator(survey.Required))
+
+	txResp := waitForTX(cmd, sourceChain, txHash, "Initial IBC packet", "Initial IBC packet")
+	packetSequence, err := strconv.ParseUint(findPacketSequence(txResp), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	connection := findConnection(txResp)
+	connection.ChannelA.ChainID = sourceChain.ChainID()
+	connection.ChannelB.ChainID = destinationChain.ChainID()
+
+	rly.RelayPacket(ctx, connection, packetSequence)
+
+	fmt.Println()
+	fmt.Println("Relay seemingly successful!")
+}
+
+func selfRelay(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+
+	logger, _ := zap.NewProduction()
+	defer logger.Sync() // flushes buffer, if any
+	rly := gorelayer.InitRly(logger)
+
+	sourceChainID := args[1]
+	destinationChainID := args[2]
+	txHash := args[3]
+
+	var sourceChain chains.Chain
+	var destinationChain chains.Chain
+
+	if destinationChainID == sourceChainID {
+		panic(fmt.Errorf("Source and destination are the same chain"))
+	}
+
+	foundSource := false
+	for _, chain := range chains.Chains {
+		if string(chain.ChainID()) == sourceChainID {
+			sourceChain = chain
+			foundSource = true
+			break
+		}
+	}
+
+	if !foundSource {
+		panic(fmt.Errorf("Source chain %s not found", sourceChain))
+	}
+
+	foundDestination := false
+	for _, chain := range chains.Chains {
+		if string(chain.ChainID()) == destinationChainID {
+			sourceChain = chain
+			foundDestination = true
+			break
+		}
+	}
+	if !foundDestination {
+		panic(fmt.Errorf("Destination chain %s not found", destinationChainID))
+	}
 
 	txResp := waitForTX(cmd, sourceChain, txHash, "Initial IBC packet", "Initial IBC packet")
 	packetSequence, err := strconv.ParseUint(findPacketSequence(txResp), 10, 64)

--- a/gon-cli/cmd/tools.go
+++ b/gon-cli/cmd/tools.go
@@ -21,9 +21,9 @@ const (
 	generateTraceOption  OptionString = "Generate Trace manually"
 	generateTraceCommand              = "generate-trace"
 
-	/*generateTraceSimplyOption  OptionString = "Generate Trace Simply manually"
+	generateTraceSimplyOption  OptionString = "Generate Trace Simply manually"
 	generateTraceSimplyCommand              = "generate-trace-simpy"
-	*/
+
 	relayerCommandsOption  OptionString = "Relayer Commands"
 	relayerCommandsCommand              = "relayer-commands"
 )
@@ -36,7 +36,7 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 		queryTransactionOption,
 		calculateClassHashOption,
 		generateTraceOption,
-		//generateTraceSimplyOption,
+		generateTraceSimplyOption,
 		relayerCommandsOption,
 	}
 
@@ -55,8 +55,8 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 			toolsChoice = calculateClassHashOption
 		case generateTraceCommand:
 			toolsChoice = generateTraceOption
-		/*case generateTraceSimplyCommand:
-		toolsChoice = generateTraceSimplyOption*/
+		case generateTraceSimplyCommand:
+			toolsChoice = generateTraceSimplyOption
 		case relayerCommandsCommand:
 			toolsChoice = relayerCommandsOption
 		default:
@@ -79,8 +79,8 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 		calculateClassHashInteractive()
 	case generateTraceOption:
 		generateTraceInteractive()
-	/*case generateTraceSimplyOption:
-	generateTraceSimplyInteractive()*/
+	case generateTraceSimplyOption:
+		generateTraceSimplyInteractive()
 
 	case relayerCommandsOption:
 		relayerCommandsInteractive()

--- a/gon-cli/cmd/tools.go
+++ b/gon-cli/cmd/tools.go
@@ -21,6 +21,9 @@ const (
 	generateTraceOption  OptionString = "Generate Trace manually"
 	generateTraceCommand              = "generate-trace"
 
+	/*generateTraceSimplyOption  OptionString = "Generate Trace Simply manually"
+	generateTraceSimplyCommand              = "generate-trace-simpy"
+	*/
 	relayerCommandsOption  OptionString = "Relayer Commands"
 	relayerCommandsCommand              = "relayer-commands"
 )
@@ -33,6 +36,7 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 		queryTransactionOption,
 		calculateClassHashOption,
 		generateTraceOption,
+		//generateTraceSimplyOption,
 		relayerCommandsOption,
 	}
 
@@ -51,6 +55,8 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 			toolsChoice = calculateClassHashOption
 		case generateTraceCommand:
 			toolsChoice = generateTraceOption
+		/*case generateTraceSimplyCommand:
+		toolsChoice = generateTraceSimplyOption*/
 		case relayerCommandsCommand:
 			toolsChoice = relayerCommandsOption
 		default:
@@ -73,6 +79,9 @@ func toolsInteractive(cmd *cobra.Command, args []string) {
 		calculateClassHashInteractive()
 	case generateTraceOption:
 		generateTraceInteractive()
+	/*case generateTraceSimplyOption:
+	generateTraceSimplyInteractive()*/
+
 	case relayerCommandsOption:
 		relayerCommandsInteractive()
 	default:

--- a/gon-cli/cmd/tools_connections.go
+++ b/gon-cli/cmd/tools_connections.go
@@ -2,6 +2,19 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/gjermundgaraba/gon/chains"
+)
+
+var (
+	ReverseChainMap = map[chains.ChainID]string{
+		chains.IRISChain.ChainID():     "i",
+		chains.StargazeChain.ChainID(): "s",
+		chains.JunoChain.ChainID():     "j",
+		chains.OmniFlixChain.ChainID(): "o",
+		chains.UptickChain.ChainID():   "u",
+	}
 )
 
 func listConnections() {
@@ -19,4 +32,30 @@ func listConnections() {
 			fmt.Println()
 		}
 	}
+}
+
+func getMatrix() map[string]string {
+	matrix := make(map[string]string)
+	connections := chains.Connections
+	var prevChainA chains.ChainID
+	var prevChainB chains.ChainID
+	for _, connection := range connections {
+		l1 := ReverseChainMap[connection.ChannelA.ChainID]
+		l2 := ReverseChainMap[connection.ChannelB.ChainID]
+		if prevChainA == connection.ChannelA.ChainID && prevChainB == connection.ChannelB.ChainID {
+			matrix[strings.ToUpper(l1)+l2] = connection.ChannelB.Port + "/" + connection.ChannelB.Channel
+			matrix[strings.ToUpper(l1+l2)] = connection.ChannelB.Port + "/" + connection.ChannelB.Channel
+			matrix[l2+l1] = connection.ChannelA.Port + "/" + connection.ChannelA.Channel
+			matrix[strings.ToUpper(l2)+l1] = connection.ChannelA.Port + "/" + connection.ChannelA.Channel
+		} else {
+			matrix[l1+l2] = connection.ChannelB.Port + "/" + connection.ChannelB.Channel
+			matrix[l1+strings.ToUpper(l2)] = connection.ChannelB.Port + "/" + connection.ChannelB.Channel
+			matrix[l2+l1] = connection.ChannelA.Port + "/" + connection.ChannelA.Channel
+			matrix[l2+strings.ToUpper(l1)] = connection.ChannelA.Port + "/" + connection.ChannelA.Channel
+
+		}
+		prevChainA = connection.ChannelA.ChainID
+		prevChainB = connection.ChannelB.ChainID
+	}
+	return matrix
 }

--- a/gon-cli/cmd/tools_generate_trace_simply.go
+++ b/gon-cli/cmd/tools_generate_trace_simply.go
@@ -11,20 +11,15 @@ func generateTraceSimplyInteractive() {
 	className := askForString("Enter the original class name", survey.WithValidator(survey.Required))
 	simplyPath := askForString("Enter path (ie. i1j2u)", survey.WithValidator(survey.Required))
 
-	simplyPath = pathReducer2(simplyPath)
-
-	PORT_CHANNEL_MATRIX := map[string]string{
-		"01": "seg1",
-		"02": "seg2",
-		"03": "seg3",
-		// add more entries as needed
-	}
-
+	simplyPath = pathReducer(simplyPath)
+	PORT_CHANNEL_MATRIX := getMatrix()
 	fullPath := ""
 	for i := 0; i < len(simplyPath); i++ {
+		if len(simplyPath) < (i + 2) {
+			break
+		}
 		ch := simplyPath[i : i+2]
 		seg, ok := PORT_CHANNEL_MATRIX[ch]
-
 		if ok {
 			fullPath = seg + "/" + fullPath
 		}
@@ -41,66 +36,16 @@ func generateTraceSimplyInteractive() {
 	}*/
 }
 
-// func pathReducer(path string) string {
-// 	newPath := ""
-// 	pal := ""
-// 	piece := ""
-// 	letter := ""
-// 	channel := ""
-// 	fLetter := ""
-
-// 	for i := 0; i < len(path); i += 3 {
-// 		piece = path[i:2]
-// 		letter = piece[0:1]
-// 		channel = piece[1:2]
-// 		if channel == "2" {
-// 			letter = strings.ToUpper(letter)
-// 		}
-// 		newPath = newPath + letter
-// 	}
-
-// 	pal = findPalindrome(newPath)
-// 	for pal != "" {
-// 		fLetter = pal[0:1]
-// 		newPath = strings.Replace(newPath, pal, fLetter, -1)
-// 		pal = findPalindrome(newPath)
-// 	}
-
-// 	return newPath
-// }
-
-// func findPalindrome(path string) string {
-// 	length := len(path)
-// 	reverseSubstring := ""
-// 	substring := ""
-// 	minPalindrome := ""
-// 	for i := 0; i < length; i++ {
-// 		for j := 2; j <= length-i; j++ {
-// 			substring = path[i:j]
-// 			reverseSubstring = reverseString(substring)
-// 			if substring == reverseSubstring {
-// 				minPalindrome = substring
-// 			}
-// 		}
-// 	}
-// 	return minPalindrome
-// }
-
-// func reverseString(str string) string {
-// 	byte_str := []rune(str)
-// 	for i, j := 0, len(byte_str)-1; i < j; i, j = i+1, j-1 {
-// 		byte_str[i], byte_str[j] = byte_str[j], byte_str[i]
-// 	}
-// 	return string(byte_str)
-// }
-
-func pathReducer2(input string) string {
+func pathReducer(input string) string {
 	newPath := ""
 	for i := 0; i < len(input); i += 2 {
+		if len(input) < (i + 2) {
+			newPath += input[i : i+1]
+			break
+		}
 		piece := input[i : i+2]
 		letter := string(piece[0])
 		channel := string(piece[1])
-
 		if channel == "2" {
 			letter = strings.ToUpper(letter)
 		}

--- a/gon-cli/cmd/tools_generate_trace_simply.go
+++ b/gon-cli/cmd/tools_generate_trace_simply.go
@@ -4,13 +4,17 @@ import (
 	"fmt"
 	"strings"
 
+	"regexp"
+
 	"github.com/AlecAivazis/survey/v2"
 )
 
+var cleanPath = regexp.MustCompile(`[^ijous12]+`)
+
 func generateTraceSimplyInteractive() {
 	className := askForString("Enter the original class name", survey.WithValidator(survey.Required))
-	simplyPath := askForString("Enter path (ie. i1j2u)", survey.WithValidator(survey.Required))
-
+	simplyPath := askForString("Enter path (ie. i1j2u or i --(1)--> j --(2)--> u)", survey.WithValidator(survey.Required))
+	simplyPath = cleanPath.ReplaceAllString(simplyPath, "")
 	simplyPath = pathReducer(simplyPath)
 	PORT_CHANNEL_MATRIX := getMatrix()
 	fullPath := ""

--- a/gon-cli/cmd/tools_generate_trace_simply.go
+++ b/gon-cli/cmd/tools_generate_trace_simply.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+func generateTraceSimplyInteractive() {
+	className := askForString("Enter the original class name", survey.WithValidator(survey.Required))
+	simplyPath := askForString("Enter path (ie. i1j2u)", survey.WithValidator(survey.Required))
+
+	simplyPath = pathReducer2(simplyPath)
+
+	PORT_CHANNEL_MATRIX := map[string]string{
+		"01": "seg1",
+		"02": "seg2",
+		"03": "seg3",
+		// add more entries as needed
+	}
+
+	fullPath := ""
+	for i := 0; i < len(simplyPath); i++ {
+		ch := simplyPath[i : i+2]
+		seg, ok := PORT_CHANNEL_MATRIX[ch]
+
+		if ok {
+			fullPath = seg + "/" + fullPath
+		}
+	}
+
+	trace := fullPath + className
+
+	fmt.Println("Full IBC class trace:")
+	fmt.Println(trace)
+	/*if len(strings.Split(trace, "/")) > 2 && currentChain.NFTImplementation() == chains.CosmosSDK {
+		fmt.Println()
+		fmt.Println("Class hash:")
+		fmt.Println(calculateClassHash(trace))
+	}*/
+}
+
+// func pathReducer(path string) string {
+// 	newPath := ""
+// 	pal := ""
+// 	piece := ""
+// 	letter := ""
+// 	channel := ""
+// 	fLetter := ""
+
+// 	for i := 0; i < len(path); i += 3 {
+// 		piece = path[i:2]
+// 		letter = piece[0:1]
+// 		channel = piece[1:2]
+// 		if channel == "2" {
+// 			letter = strings.ToUpper(letter)
+// 		}
+// 		newPath = newPath + letter
+// 	}
+
+// 	pal = findPalindrome(newPath)
+// 	for pal != "" {
+// 		fLetter = pal[0:1]
+// 		newPath = strings.Replace(newPath, pal, fLetter, -1)
+// 		pal = findPalindrome(newPath)
+// 	}
+
+// 	return newPath
+// }
+
+// func findPalindrome(path string) string {
+// 	length := len(path)
+// 	reverseSubstring := ""
+// 	substring := ""
+// 	minPalindrome := ""
+// 	for i := 0; i < length; i++ {
+// 		for j := 2; j <= length-i; j++ {
+// 			substring = path[i:j]
+// 			reverseSubstring = reverseString(substring)
+// 			if substring == reverseSubstring {
+// 				minPalindrome = substring
+// 			}
+// 		}
+// 	}
+// 	return minPalindrome
+// }
+
+// func reverseString(str string) string {
+// 	byte_str := []rune(str)
+// 	for i, j := 0, len(byte_str)-1; i < j; i, j = i+1, j-1 {
+// 		byte_str[i], byte_str[j] = byte_str[j], byte_str[i]
+// 	}
+// 	return string(byte_str)
+// }
+
+func pathReducer2(input string) string {
+	newPath := ""
+	for i := 0; i < len(input); i += 2 {
+		piece := input[i : i+2]
+		letter := string(piece[0])
+		channel := string(piece[1])
+
+		if channel == "2" {
+			letter = strings.ToUpper(letter)
+		}
+
+		newPath += letter
+	}
+
+	reverse := func(s string) string {
+		runes := []rune(s)
+		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+			runes[i], runes[j] = runes[j], runes[i]
+		}
+		return string(runes)
+	}
+
+	findPalindrome := func(path string) string {
+		length := len(path)
+		minPalindrome := ""
+
+		for i := 0; i < length; i++ {
+			for j := 2; j <= length-i; j++ {
+				substring := path[i : i+j]
+				reverseSubstring := reverse(substring)
+
+				if substring == reverseSubstring {
+					if minPalindrome == "" || len(substring) < len(minPalindrome) {
+						minPalindrome = substring
+					}
+				}
+			}
+		}
+
+		return minPalindrome
+	}
+
+	pal := findPalindrome(newPath)
+
+	for pal != "" {
+		fLetter := string(pal[0])
+		newPath = strings.ReplaceAll(newPath, pal, fLetter)
+		pal = findPalindrome(newPath)
+	}
+
+	return newPath
+}

--- a/gon-cli/go.mod
+++ b/gon-cli/go.mod
@@ -23,6 +23,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.5.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -188,7 +189,6 @@ require (
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )


### PR DESCRIPTION
1. Added the ability to print the path by simply putting the flows, for example **"i --(1)--> s --(1)--> j --(1)--> u"**. It also processes backtracks.
2. Added a command to do self relay directly without using interactive: e.g. 
    ```bash
    gon self-relay-direct chain_idA chain_idB txhash --self-relay
   ```